### PR TITLE
Added Support for controlling OTA Package Length

### DIFF
--- a/utils/send_ota.py
+++ b/utils/send_ota.py
@@ -4,7 +4,6 @@ import paho.mqtt.client as mqtt
 import os
 import sys
 import argparse
-import datetime
 import hashlib
 import base64
 import time
@@ -17,9 +16,11 @@ topic = "esp8266-"
 inTopic = topic + "in"
 outTopic = topic + "out"
 send_topic = ""
-name=""
-passw=""
-q = queue.Queue();
+name = ""
+passw = ""
+q = queue.Queue()
+maxMQTTMessageLength = 768
+
 
 def regex(pattern, txt, group):
     group.clear()
@@ -33,12 +34,14 @@ def regex(pattern, txt, group):
         return True
     return False
 
+
 def on_connect(client, userdata, flags, rc):
     print("Connected with result code "+str(rc))
 
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.
     client.subscribe("{}/#".format(outTopic))
+
 
 # The callback for when a PUBLISH message is received from the server.
 def on_message(client, userdata, msg):
@@ -78,6 +81,7 @@ def wait_for(nodes, msgtype, maxTime):
     #print("Elapsed time waiting for {} messages: {} seconds".format(msgtype, time.time() - origTime))
     return seen
 
+
 def send_firmware(client, data, nodes):
     md5 = base64.b64encode(hashlib.md5(data).digest())
     payload = "md5:%s,len:%d" %(md5.decode(), len(data))
@@ -90,9 +94,9 @@ def send_firmware(client, data, nodes):
     print("Updating firmware on the following nodes:\n\t{}".format("\n\t".join(nodes)))
     pos = 0
     while len(data):
-        d = data[0:768]
+        d = data[0:maxMQTTMessageLength]
         b64d = base64.b64encode(d)
-        data = data[768:]
+        data = data[maxMQTTMessageLength:]
         topic = "{}{}".format(send_topic, str(pos))
         client.publish(topic, b64d)
         expected_md5 = hashlib.md5(d).hexdigest().encode('utf-8')
@@ -116,12 +120,13 @@ def send_firmware(client, data, nodes):
                 print("Got unexpected address 0x{} (expected: 0x{}) from node {}".format(addr, pos, node))
                 return
             if md5 != expected_md5:
-                print("Got unexpected md5 for node {} at 0x{}".format(node, addr))
+                print("Got unexpected md5 for node {} at 0x{},\n"
+                      "maybe the send Packages are to large for your MCU, if this happens every time try using the Argument: --packageLength".format(node, addr))
                 print("\t {} (expected: {})".format(md5, expected_md5))
                 return
         pos += len(d)
-        if pos % (768 * 13) == 0:
-            print("Transmitted %d bytes" % (pos))
+        if pos % (int(10000/maxMQTTMessageLength)*maxMQTTMessageLength) == 0: #aproximately every 10kb of send Data
+            print("Transmitted %d bytes" % pos)
     print("Completed send")
     client.publish("{}check".format(send_topic), "")
     seen = wait_for(nodes, 'check', 5)
@@ -131,7 +136,8 @@ def send_firmware(client, data, nodes):
             print("No verify result found for {}".format(node))
             err = True
         if seen[node][2] != b'MD5 Passed':
-            print("Node {} did not pass final MD5 check: {}".format(node, seen[node][2]))
+            print("Node {} did not pass final MD5 check: {},\n"
+                  "maybe the send Packages are to large for your MCU, if this happens every time try using the Argument: --packageLength".format(node, seen[node][2]))
             err = True
     if err:
         return
@@ -139,7 +145,7 @@ def send_firmware(client, data, nodes):
     client.publish("{}flash".format(send_topic), "")
 
 def main():
-    global inTopic, outTopic, name, passw, send_topic
+    global inTopic, outTopic, name, passw, send_topic, maxMQTTMessageLength
     parser = argparse.ArgumentParser()
     parser.add_argument("--bin", help="Input file");
     parser.add_argument("--id", help="Firmware ID (n HEX)");
@@ -148,11 +154,16 @@ def main():
     parser.add_argument("--user", help="MQTT broker user");
     parser.add_argument("--password", help="MQTT broker password");
     parser.add_argument("--ssl", help="MQTT broker SSL support");
-    parser.add_argument("--topic", help="MQTT mesh topic base (default: {}".format(topic))
-    parser.add_argument("--intopic", help="MQTT mesh in-topic (default: {}".format(inTopic))
-    parser.add_argument("--outtopic", help="MQTT mesh out-topic (default: {}".format(outTopic))
-    parser.add_argument("--node", help=("Specific node to send firmware to"))
+    parser.add_argument("--topic", help="MQTT mesh topic base (default: {})".format(topic))
+    parser.add_argument("--intopic", help="MQTT mesh in-topic (default: {})".format(inTopic))
+    parser.add_argument("--outtopic", help="MQTT mesh out-topic (default: {})".format(outTopic))
+    parser.add_argument("--node", help="Specific node to send firmware to")
+    parser.add_argument("--packageLength", help="Max ESP Payload Length, lower when always MD5 Mismatch (default: {})".format(outTopic))
     args = parser.parse_args()
+
+    if args.packageLength:
+        maxMQTTMessageLength = int(args.packageLength)
+
     if not os.path.isfile(args.bin):
         print("File: " + args.bin + " does not exist")
         sys.exit(1)
@@ -194,15 +205,17 @@ def main():
     client.on_connect = on_connect
     client.on_message = on_message
 
-    client.connect(args.broker, args.port, 60)
+    client.connect(args.broker, int(args.port), 60)
     client.loop_start()
 
     fh = open(args.bin, "rb")
-    data = fh.read();
+    data = fh.read()
     fh.close()
 
     send_firmware(client, data, [args.node] if args.node else [])
 
     client.loop_stop()
     client.disconnect()
+
+
 main()


### PR DESCRIPTION
Since the ESP can only handle a specific maximal length of Packages, and this Length is dependent on different Factors like Libary Versions and build Parameters, I have added an option to controll the Package length in the send OTA script so everyone can use their ESP's without searching for how to enlarge the maximal Package Size. (Default is same as were hardcoded before)